### PR TITLE
feat: プロジェクトとユーザーの中間テーブルを追加、プロジェクト詳細にメンバーを表示

### DIFF
--- a/containers/laravel/app/Http/Controllers/Api/UserController.php
+++ b/containers/laravel/app/Http/Controllers/Api/UserController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Spatie\QueryBuilder\QueryBuilder;
+use App\Models\User;
+
+class UserController extends Controller
+{
+    public function index(){
+      $users = QueryBuilder::for(User::class)
+          ->allowedFilters(['name', 'email'])
+          ->get();
+      return response()->json($users);
+    }
+}

--- a/containers/laravel/app/Http/Controllers/ProjectController.php
+++ b/containers/laravel/app/Http/Controllers/ProjectController.php
@@ -16,13 +16,13 @@ class ProjectController extends Controller
   {
     $this->authorize('viewAny', Project::class);
     return Inertia::render('projects/Index', [
-      'projects' => Project::all(),
+      'projects' => Project::with(['members.user'])->get(),
     ]);
   }
 
   public function show($id)
   {
-    $project = Project::findOrFail($id);
+    $project = Project::with(['members.user'])->findOrFail($id);
     $this->authorize('view', $project);
     return Inertia::render('projects/Show', [
       'project' => $project,
@@ -39,21 +39,22 @@ class ProjectController extends Controller
   {
     $this->authorize('create', Project::class);
     $project = Project::create($request->validated());
+    $project->members()->createMany($request->members);
     return redirect()->route('projects.index');
   }
 
   public function edit($id)
   {
-    $project = Project::findOrFail($id);
+    $project = Project::with(['members.user'])->findOrFail($id);
     $this->authorize('update', $project);
     return Inertia::render('projects/Edit', [
       'project' => $project,
     ]);
   }
 
-  public function update(Request $request, $id)
+  public function update(ProjectRequest $request, $id)
   {
-    $project = Project::findOrFail($id);
+    $project = Project::with(['members.user'])->findOrFail($id);
     $project->update($request->validated());
     $this->authorize('update', $project);
     return redirect()->route('projects.index');

--- a/containers/laravel/app/Http/Controllers/UserController.php
+++ b/containers/laravel/app/Http/Controllers/UserController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Inertia\Inertia;
 use App\Models\User;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Spatie\QueryBuilder\QueryBuilder;
 
 class UserController extends Controller
 {
@@ -14,10 +15,12 @@ class UserController extends Controller
     {
         $this->authorize('viewAny', User::class);
 
-        $user = auth()->user(); //ユーザ情報を取得
+        $users = QueryBuilder::for(User::class)
+            ->allowedFilters(['name', 'email'])
+            ->get();
 
         return Inertia::render('users/Index',[
-            'users' => User::all(),
+            'users' => $users,
         ]);
     }
 

--- a/containers/laravel/app/Models/Member.php
+++ b/containers/laravel/app/Models/Member.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Member extends Model
+{
+    protected $table = 'project_user';
+
+    protected $fillable = [
+        'project_id',
+        'user_id',
+        'role',
+        'status',
+        'assigned_at',
+    ];
+
+    public function project(): BelongsTo
+    {
+        return $this->belongsTo(Project::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * アクセサ: メンバー名を取得
+     */
+    public function getNameAttribute(): string
+    {
+        return $this->user ? $this->user->name : '';
+    }
+
+    /**
+     * アクセサ: フロントエンド用の配列形式
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'role' => $this->role,
+            'status' => $this->status,
+            'assigned_at' => $this->assigned_at,
+            'user' => $this->user ? $this->user->toArray() : null,
+            'user_id' => $this->user_id,
+        ];
+    }
+}

--- a/containers/laravel/app/Models/Project.php
+++ b/containers/laravel/app/Models/Project.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
  * @property string $title
@@ -16,6 +17,11 @@ class Project extends Model
         'description',
         'archived_at'
     ];
+
+    public function members(): HasMany
+    {
+        return $this->hasMany(Member::class);
+    }
     /**
      * Archive the project
      *

--- a/containers/laravel/app/Models/User.php
+++ b/containers/laravel/app/Models/User.php
@@ -7,13 +7,14 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Fortify\TwoFactorAuthenticatable;
+use Laravel\Sanctum\HasApiTokens;
 use App\Enums\UserRole;
 use Illuminate\Support\Facades\Log;
 
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable, TwoFactorAuthenticatable;
+    use HasApiTokens, HasFactory, Notifiable, TwoFactorAuthenticatable;
 
     /**
      * The attributes that are mass assignable.

--- a/containers/laravel/composer.json
+++ b/containers/laravel/composer.json
@@ -14,9 +14,11 @@
         "inertiajs/inertia-laravel": "^2.0",
         "laravel/fortify": "^1.30",
         "laravel/framework": "^12.0",
+        "laravel/sanctum": "^4.2",
         "laravel/tinker": "^2.10.1",
         "laravel/wayfinder": "^0.1.9",
-        "myclabs/deep-copy": "^1.13"
+        "myclabs/deep-copy": "^1.13",
+        "spatie/laravel-query-builder": "^6.3"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/containers/laravel/composer.lock
+++ b/containers/laravel/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4a17906c73b3237d6b42262d11c5c944",
+    "content-hash": "e25fd878844196512deb65f5a7ffb7e1",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -1723,6 +1723,70 @@
                 "source": "https://github.com/laravel/prompts/tree/v0.3.7"
             },
             "time": "2025-09-19T13:47:56+00:00"
+        },
+        {
+            "name": "laravel/sanctum",
+            "version": "v4.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/sanctum.git",
+                "reference": "fd6df4f79f48a72992e8d29a9c0ee25422a0d677"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/sanctum/zipball/fd6df4f79f48a72992e8d29a9c0ee25422a0d677",
+                "reference": "fd6df4f79f48a72992e8d29a9c0ee25422a0d677",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "illuminate/console": "^11.0|^12.0",
+                "illuminate/contracts": "^11.0|^12.0",
+                "illuminate/database": "^11.0|^12.0",
+                "illuminate/support": "^11.0|^12.0",
+                "php": "^8.2",
+                "symfony/console": "^7.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.6",
+                "orchestra/testbench": "^9.0|^10.0",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Sanctum\\SanctumServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Sanctum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Laravel Sanctum provides a featherweight authentication system for SPAs and simple APIs.",
+            "keywords": [
+                "auth",
+                "laravel",
+                "sanctum"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/sanctum/issues",
+                "source": "https://github.com/laravel/sanctum"
+            },
+            "time": "2025-07-09T19:45:24+00:00"
         },
         {
             "name": "laravel/serializable-closure",
@@ -4008,6 +4072,141 @@
                 "source": "https://github.com/ramsey/uuid/tree/4.9.1"
             },
             "time": "2025-09-04T20:59:21+00:00"
+        },
+        {
+            "name": "spatie/laravel-package-tools",
+            "version": "1.92.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-package-tools.git",
+                "reference": "f09a799850b1ed765103a4f0b4355006360c49a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-package-tools/zipball/f09a799850b1ed765103a4f0b4355006360c49a5",
+                "reference": "f09a799850b1ed765103a4f0b4355006360c49a5",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^9.28|^10.0|^11.0|^12.0",
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.5",
+                "orchestra/testbench": "^7.7|^8.0|^9.0|^10.0",
+                "pestphp/pest": "^1.23|^2.1|^3.1",
+                "phpunit/php-code-coverage": "^9.0|^10.0|^11.0",
+                "phpunit/phpunit": "^9.5.24|^10.5|^11.5",
+                "spatie/pest-plugin-test-time": "^1.1|^2.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\LaravelPackageTools\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Tools for creating Laravel packages",
+            "homepage": "https://github.com/spatie/laravel-package-tools",
+            "keywords": [
+                "laravel-package-tools",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-package-tools/issues",
+                "source": "https://github.com/spatie/laravel-package-tools/tree/1.92.7"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-07-17T15:46:43+00:00"
+        },
+        {
+            "name": "spatie/laravel-query-builder",
+            "version": "6.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-query-builder.git",
+                "reference": "ee3c98235616f88c11e75d3df5ea48dc7b20dd93"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-query-builder/zipball/ee3c98235616f88c11e75d3df5ea48dc7b20dd93",
+                "reference": "ee3c98235616f88c11e75d3df5ea48dc7b20dd93",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/database": "^10.0|^11.0|^12.0",
+                "illuminate/http": "^10.0|^11.0|^12.0",
+                "illuminate/support": "^10.0|^11.0|^12.0",
+                "php": "^8.2",
+                "spatie/laravel-package-tools": "^1.11"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "larastan/larastan": "^2.7 || ^3.3",
+                "mockery/mockery": "^1.4",
+                "orchestra/testbench": "^7.0|^8.0|^10.0",
+                "pestphp/pest": "^2.0|^3.7",
+                "phpunit/phpunit": "^10.0|^11.5.3",
+                "spatie/invade": "^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\QueryBuilder\\QueryBuilderServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\QueryBuilder\\": "src",
+                    "Spatie\\QueryBuilder\\Database\\Factories\\": "database/factories"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Vanderbist",
+                    "email": "alex@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Easily build Eloquent queries from API requests",
+            "homepage": "https://github.com/spatie/laravel-query-builder",
+            "keywords": [
+                "laravel-query-builder",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-query-builder/issues",
+                "source": "https://github.com/spatie/laravel-query-builder"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                }
+            ],
+            "time": "2025-08-04T07:36:33+00:00"
         },
         {
             "name": "symfony/clock",

--- a/containers/laravel/config/auth.php
+++ b/containers/laravel/config/auth.php
@@ -40,6 +40,10 @@ return [
             'driver' => 'session',
             'provider' => 'users',
         ],
+        'sanctum' => [
+            'driver' => 'sanctum',
+            'provider' => null,
+        ],
     ],
 
     /*

--- a/containers/laravel/config/query-builder.php
+++ b/containers/laravel/config/query-builder.php
@@ -1,0 +1,84 @@
+<?php
+
+return [
+
+    /*
+     * By default the package will use the `include`, `filter`, `sort`
+     * and `fields` query parameters as described in the readme.
+     *
+     * You can customize these query string parameters here.
+     */
+    'parameters' => [
+        'include' => 'include',
+
+        'filter' => 'filter',
+
+        'sort' => 'sort',
+
+        'fields' => 'fields',
+
+        'append' => 'append',
+    ],
+
+    /*
+     * Related model counts are included using the relationship name suffixed with this string.
+     * For example: GET /users?include=postsCount
+     */
+    'count_suffix' => 'Count',
+
+    /*
+     * Related model exists are included using the relationship name suffixed with this string.
+     * For example: GET /users?include=postsExists
+     */
+    'exists_suffix' => 'Exists',
+
+    /*
+     * By default the package will throw an `InvalidFilterQuery` exception when a filter in the
+     * URL is not allowed in the `allowedFilters()` method.
+     */
+    'disable_invalid_filter_query_exception' => false,
+
+    /*
+     * By default the package will throw an `InvalidSortQuery` exception when a sort in the
+     * URL is not allowed in the `allowedSorts()` method.
+     */
+    'disable_invalid_sort_query_exception' => false,
+
+    /*
+     * By default the package will throw an `InvalidIncludeQuery` exception when an include in the
+     * URL is not allowed in the `allowedIncludes()` method.
+     */
+    'disable_invalid_includes_query_exception' => false,
+
+    /*
+     * By default, the package expects relationship names to be snake case plural when using fields[relationship].
+     * For example, fetching the id and name for a userOwner relation would look like this:
+     * GET /users?fields[user_owner]=id,name
+     *
+     * Set this to `false` if you don't want that and keep the requested relationship names as-is and allows you to
+     * request the fields using a camelCase relationship name:
+     * GET /users?fields[userOwner]=id,name
+     */
+    'convert_relation_names_to_snake_case_plural' => true,
+
+    /*
+     * This is an alternative to the previous option if you don't want to use default snake case plural for fields[relationship].
+     * It resolves the table name for the related model using the Laravel model class and, based on your chosen strategy,
+     * matches it with the fields[relationship] provided in the request.
+     *
+     * Set this to one of `snake_case`, `camelCase` or `none` if you want to enable table name resolution in addition to the relation name resolution.
+     * `snake_case` => Matches table names like 'topOrders' to `fields[top_orders]`
+     * `camelCase` => Matches table names like 'top_orders' to 'fields[topOrders]'
+     * `none` => Uses the exact table name
+     */
+    'convert_relation_table_name_strategy' => false,
+
+    /*
+     * By default, the package expects the field names to match the database names
+     * For example, fetching the field named firstName would look like this:
+     * GET /users?fields=firstName
+     *
+     * Set this to `true` if you want to convert the firstName into first_name for the underlying query
+     */
+    'convert_field_names_to_snake_case' => false,
+];

--- a/containers/laravel/config/sanctum.php
+++ b/containers/laravel/config/sanctum.php
@@ -1,0 +1,84 @@
+<?php
+
+use Laravel\Sanctum\Sanctum;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Stateful Domains
+    |--------------------------------------------------------------------------
+    |
+    | Requests from the following domains / hosts will receive stateful API
+    | authentication cookies. Typically, these should include your local
+    | and production domains which access your API via a frontend SPA.
+    |
+    */
+
+    'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
+        '%s%s',
+        'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
+        Sanctum::currentApplicationUrlWithPort(),
+        // Sanctum::currentRequestHost(),
+    ))),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Sanctum Guards
+    |--------------------------------------------------------------------------
+    |
+    | This array contains the authentication guards that will be checked when
+    | Sanctum is trying to authenticate a request. If none of these guards
+    | are able to authenticate the request, Sanctum will use the bearer
+    | token that's present on an incoming request for authentication.
+    |
+    */
+
+    'guard' => ['web'],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Expiration Minutes
+    |--------------------------------------------------------------------------
+    |
+    | This value controls the number of minutes until an issued token will be
+    | considered expired. This will override any values set in the token's
+    | "expires_at" attribute, but first-party sessions are not affected.
+    |
+    */
+
+    'expiration' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Token Prefix
+    |--------------------------------------------------------------------------
+    |
+    | Sanctum can prefix new tokens in order to take advantage of numerous
+    | security scanning initiatives maintained by open source platforms
+    | that notify developers if they commit tokens into repositories.
+    |
+    | See: https://docs.github.com/en/code-security/secret-scanning/about-secret-scanning
+    |
+    */
+
+    'token_prefix' => env('SANCTUM_TOKEN_PREFIX', ''),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Sanctum Middleware
+    |--------------------------------------------------------------------------
+    |
+    | When authenticating your first-party SPA with Sanctum you may need to
+    | customize some of the middleware Sanctum uses while processing the
+    | request. You may change the middleware listed below as required.
+    |
+    */
+
+    'middleware' => [
+        'authenticate_session' => Laravel\Sanctum\Http\Middleware\AuthenticateSession::class,
+        'encrypt_cookies' => Illuminate\Cookie\Middleware\EncryptCookies::class,
+        'validate_csrf_token' => Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class,
+    ],
+
+];

--- a/containers/laravel/database/migrations/2025_10_07_180844_create_project_user_table.php
+++ b/containers/laravel/database/migrations/2025_10_07_180844_create_project_user_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('project_user', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('project_id')->constrained('projects');
+            $table->foreignId('user_id')->constrained('users');
+            $table->enum('role', ['manager', 'member']);
+            $table->enum('status', ['active', 'inactive']);
+            $table->dateTime('assigned_at');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('project_user');
+    }
+};

--- a/containers/laravel/resources/js/app.ts
+++ b/containers/laravel/resources/js/app.ts
@@ -5,6 +5,17 @@ import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
 import type { DefineComponent } from 'vue';
 import { createApp, h } from 'vue';
 import { initializeTheme } from './composables/useAppearance';
+import axios from 'axios';
+
+// Sanctum用のaxios設定
+axios.defaults.withCredentials = true;
+axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
+
+// CSRFトークンをaxiosに設定
+const token = document.head.querySelector('meta[name="csrf-token"]');
+if (token) {
+    axios.defaults.headers.common['X-CSRF-TOKEN'] = token.getAttribute('content');
+}
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 

--- a/containers/laravel/resources/js/pages/projects/AddMemberModal.vue
+++ b/containers/laravel/resources/js/pages/projects/AddMemberModal.vue
@@ -1,0 +1,54 @@
+<template>
+  <Dialog >
+    <DialogTrigger as-child>
+      <Button>Add Member</Button>
+    </DialogTrigger>
+    <DialogContent>
+      <DialogHeader>
+        <DialogTitle>Add Member</DialogTitle>
+      </DialogHeader>
+      <Form v-slot="{ errors, processing }">
+        <div class="grid gap-2">
+          <Label for="name">名前</Label>
+          <Input id="name" name="name" v-model="name" />
+          <Label for="email">メールアドレス</Label>
+          <Input id="email" name="email" v-model="email" />
+          <Button type="button" @click="searchUsers" :disabled="processing">検索</Button>
+        </div>
+      </Form>
+      <div class="grid gap-2">
+        <div v-for="user in users" :key="user.id">
+          <p>{{ user.name }} {{ user.email }}</p>
+          <Button type="button" @click="emit('addMember', user)">追加</Button>
+        </div>
+      </div>
+    </DialogContent>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { Dialog } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { DialogTrigger } from '@/components/ui/dialog';
+import { DialogContent } from '@/components/ui/dialog';
+import { DialogHeader } from '@/components/ui/dialog';
+import { DialogTitle } from '@/components/ui/dialog';
+import { Form } from '@inertiajs/vue3';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import type { User } from '@/types';
+import { ref } from 'vue';
+import axios from 'axios';
+
+const emit = defineEmits<{
+  addMember: [user: User]
+}>();
+
+const name = ref('');
+const email = ref('');
+const users = ref<User[]>([]);
+const searchUsers = async () => {
+  const response = await axios.get('/api/users', { params: { name: name.value, email: email.value } });
+  users.value = response.data;
+};
+</script>

--- a/containers/laravel/resources/js/pages/projects/Create.vue
+++ b/containers/laravel/resources/js/pages/projects/Create.vue
@@ -6,6 +6,8 @@
         :title="formData.title"
         :description="formData.description"
         submit-text="Create Project"
+        :members="[]"
+        :form-props="store.form()"
         @update:title="formData.title = $event"
         @update:description="formData.description = $event"
       />
@@ -20,6 +22,7 @@ import { type BreadcrumbItem } from '@/types';
 import { Head } from '@inertiajs/vue3';
 import HeadingSmall from '@/components/HeadingSmall.vue';
 import ProjectForm from './ProjectForm.vue';
+import { store } from '@/routes/projects';
 
 const breadcrumbItems: BreadcrumbItem[] = [
   {

--- a/containers/laravel/resources/js/pages/projects/Edit.vue
+++ b/containers/laravel/resources/js/pages/projects/Edit.vue
@@ -6,8 +6,8 @@
         :title="formData.title"
         :description="formData.description"
         submit-text="Update Project"
-        @update:title="formData.title = $event"
-        @update:description="formData.description = $event"
+        :members="formData.members"
+        :form-props="update.form(props.project.id)"
       />
     </div>
   </AppLayout>
@@ -21,6 +21,7 @@ import { Head } from '@inertiajs/vue3';
 import HeadingSmall from '@/components/HeadingSmall.vue';
 import { type Project } from '@/types';
 import ProjectForm from './ProjectForm.vue';
+import { update } from '@/routes/projects';
 
 const breadcrumbItems: BreadcrumbItem[] = [
   {
@@ -36,5 +37,6 @@ const props = defineProps<{
 const formData = ref({
   title: props.project.title,
   description: props.project.description,
+  members: props.project.members,
 });
 </script>

--- a/containers/laravel/resources/js/pages/projects/MemberList.vue
+++ b/containers/laravel/resources/js/pages/projects/MemberList.vue
@@ -1,0 +1,28 @@
+<template>
+  <table>
+    <thead>
+      <tr>
+        <th>Role</th>
+        <th>Name</th>
+        <th>Status</th>
+        <th>Assigned At</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr v-for="member in members" :key="member.id">
+        <td>{{ member.role }}</td>
+        <td>{{ member.name }}</td>
+        <td>{{ member.status }}</td>
+        <td>{{ member.assigned_at }}</td>
+      </tr>
+    </tbody>
+  </table>
+</template>
+
+<script setup lang="ts">
+import { type Member } from '@/types';
+
+defineProps<{
+  members: Member[];
+}>();
+</script>

--- a/containers/laravel/resources/js/pages/projects/ProjectForm.vue
+++ b/containers/laravel/resources/js/pages/projects/ProjectForm.vue
@@ -1,8 +1,11 @@
 <template>
-  <Form v-bind="store.form()" class="flex flex-col gap-6" v-slot="{ errors, processing }">
-    <Input :value="title" @input="updateTitle" name="title" placeholder="Title" />
-    <Input :value="description" @input="updateDescription" name="description"
-      placeholder="Description" />
+  <Form v-bind="formProps" class="flex flex-col gap-6" v-slot="{ errors, processing }">
+    <Input :default-value="title" name="title" placeholder="Title" />
+    <Input :default-value="description" name="description" placeholder="Description" />
+    <MemberList :members="members" />
+    <AddMemberModal @addMember="addMember" />
+    <Input type="hidden" :name="`members[${index}].user_id`" v-for="(member, index) in members" :key="member.user_id"
+      :default-value="member.user_id" />
     <Button type="submit" class="mt-4 w-full" :tabindex="4" :disabled="processing" data-test="submit-button">
       <LoaderCircle v-if="processing" class="h-4 w-4 animate-spin" />
       {{ submitText }}
@@ -15,26 +18,47 @@ import { Input } from '@/components/ui/input';
 import { Form } from '@inertiajs/vue3';
 import { Button } from '@/components/ui/button';
 import { LoaderCircle } from 'lucide-vue-next';
-import { store } from '@/routes/projects';
+import AddMemberModal from './AddMemberModal.vue';
+import { type User, type Member } from '@/types';
+import MemberList from './MemberList.vue';
+import { ref } from 'vue';
 
 const props = defineProps<{
   title: string;
   description: string;
   submitText?: string;
+  members: Member[];
+  formProps: Record<string, any>;
 }>();
+
+const members = ref(props.members);
 
 const emit = defineEmits<{
-  'update:title': [value: string];
-  'update:description': [value: string];
+  // 'update:title': [value: string];
+  // 'update:description': [value: string];
+  'add:members': [value: Member];
 }>();
 
-const updateTitle = (event: Event) => {
-  const target = event.target as HTMLInputElement;
-  emit('update:title', target.value);
-};
+// const updateTitle = (event: Event) => {
+//   const target = event.target as HTMLInputElement;
+//   emit('update:title', target.value);
+// };
 
-const updateDescription = (event: Event) => {
-  const target = event.target as HTMLInputElement;
-  emit('update:description', target.value);
+// const updateDescription = (event: Event) => {
+//   const target = event.target as HTMLInputElement;
+//   emit('update:description', target.value);
+// };
+
+const addMember = (user: User) => {
+  var member = {
+    id: null,
+    user_id: user.id,
+    name: user.name,
+    role: user.role,
+    status: 'active',
+    assigned_at: new Date().toISOString(),
+  };
+  members.value.push(member);
+  // emit('add:members', member);
 };
 </script>

--- a/containers/laravel/resources/js/pages/projects/Show.vue
+++ b/containers/laravel/resources/js/pages/projects/Show.vue
@@ -1,7 +1,8 @@
 <template>
   <AppLayout :breadcrumbs="breadcrumbItems">
     <div class="flex h-full flex-1 flex-col gap-4 overflow-x-auto rounded-xl p-4">
-      <h1>Projects</h1>
+      <h1>{{ project.title }}</h1>
+      <MemberList :members="project.members" />
     </div>
   </AppLayout>
 </template>
@@ -9,7 +10,8 @@
 <script setup lang="ts">
 import AppLayout from '@/layouts/AppLayout.vue';
 import { type BreadcrumbItem } from '@/types';
-import { type Project } from '@/types';
+import { type Project, type Member } from '@/types';
+import MemberList from './MemberList.vue';
 
 const breadcrumbItems: BreadcrumbItem[] = [
   {

--- a/containers/laravel/resources/js/types/index.d.ts
+++ b/containers/laravel/resources/js/types/index.d.ts
@@ -39,9 +39,19 @@ export interface User {
     isManager: boolean;
 }
 
+export interface Member {
+    id: number | null;
+    name: string;
+    role: number;
+    status: string;
+    assigned_at: string;
+    user_id: number;
+}
+
 export interface Project {
     id: number;
     title: string;
     description: string;
+    members: Member[];
 }
 export type BreadcrumbItemType = BreadcrumbItem;

--- a/containers/laravel/resources/views/app.blade.php
+++ b/containers/laravel/resources/views/app.blade.php
@@ -3,6 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="csrf-token" content="{{ csrf_token() }}">
 
         {{-- Inline script to detect system dark mode preference and apply it immediately --}}
         <script>

--- a/containers/laravel/routes/api.php
+++ b/containers/laravel/routes/api.php
@@ -1,0 +1,14 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Api\UserController;
+
+Route::prefix('api')->middleware('auth')->group(function () {
+    Route::apiResource('users', UserController::class)->names([
+        'index' => 'api.users.index',
+        'store' => 'api.users.store',
+        'show' => 'api.users.show',
+        'update' => 'api.users.update',
+        'destroy' => 'api.users.destroy',
+    ]);
+});

--- a/containers/laravel/routes/web.php
+++ b/containers/laravel/routes/web.php
@@ -11,3 +11,4 @@ require __DIR__.'/settings.php';
 require __DIR__.'/auth.php';
 require __DIR__.'/users.php';
 require __DIR__.'/projects.php';
+require __DIR__.'/api.php';

--- a/internal-docs/memo/02.laravel-query-builder.md
+++ b/internal-docs/memo/02.laravel-query-builder.md
@@ -1,0 +1,41 @@
+# laravel-query-builder
+
+[github](https://github.com/spatie/laravel-query-builder)
+
+## 選定理由
+
+ - 今回の目的はLaravel最新キャッチアップなのでデファクトスタンダードに寄せたい
+ - ChatGPTに「ransackみたいなやつのデファクトスタンダードを教えて」と言ったらlaravel-query-builderを教えてもらった
+ - スターも多いし更新も盛んだし信用してよかろうと判断した
+
+## Setup
+
+[Setup](https://spatie.be/docs/laravel-query-builder/v6/installation-setup)
+
+```
+composer require spatie/laravel-query-builder
+php artisan vendor:publish --provider="Spatie\QueryBuilder\QueryBuilderServiceProvider" --tag="query-builder-config"
+```
+
+`php artisan vendor:publish以下略`の方は公式曰く
+
+>The package will automatically register its service provider.  
+>You can optionally publish the config file with:
+
+なのでやらなくていいっぽいけど見たかったのでやった
+
+## Basic Usage
+
+[Basic Usage](https://spatie.be/docs/laravel-query-builder/v6/features/filtering#content-basic-usage)
+
+```
+// GET /users?filter[name]=john&filter[email]=gmail
+
+$users = QueryBuilder::for(User::class)
+    ->allowedFilters(['name', 'email'])
+    ->get();
+
+// $users will contain all users with "john" in their name AND "gmail" in their email address
+```
+
+この時点でとりあえず動いた

--- a/internal-docs/memo/03.inertia.md
+++ b/internal-docs/memo/03.inertia.md
@@ -1,0 +1,8 @@
+# Inertiaって何
+
+つよいルーター
+
+[Inertia](https://inertiajs.com/)
+
+>Inertia isn't a framework, nor is it a replacement for your existing server-side or client-side frameworks. Rather, it's designed to work with them. Think of Inertia as glue that connects the two. Inertia does this via adapters. We currently have three official client-side adapters (React, Vue, and Svelte) and three server-side adapters (Laravel, Rails, and Phoenix).
+

--- a/internal-docs/memo/04.sanctum.md
+++ b/internal-docs/memo/04.sanctum.md
@@ -1,0 +1,260 @@
+# Sanctum
+
+[【Laravel】SanctumでAPIトークン認証の使い方とSPA認証との比較](https://qiita.com/104dev/items/0787a81f7dda892ce86a)
+
+## セットアップ手順
+
+### Laravel 11の場合（推奨）
+
+```bash
+php artisan install:api
+```
+
+このコマンドで以下が自動的に行われます：
+- `laravel/sanctum`のインストール
+- `routes/api.php`の作成
+- `bootstrap/app.php`へのAPIルート登録
+- `config/auth.php`へのSanctumガード追加
+- `User`モデルへの`HasApiTokens`トレイト追加
+- マイグレーションの実行
+
+### 手動セットアップの場合（参考）
+
+上記コマンドが使えない場合や、何が行われるか理解するための参考情報です。
+
+#### 1. Sanctumパッケージのインストール
+
+```bash
+composer require laravel/sanctum
+```
+
+#### 2. config/auth.php の設定
+
+`guards`配列にSanctumガードを追加：
+
+```php
+'guards' => [
+    'web' => [
+        'driver' => 'session',
+        'provider' => 'users',
+    ],
+    'sanctum' => [
+        'driver' => 'sanctum',
+        'provider' => null,
+    ],
+],
+```
+
+#### 3. bootstrap/app.php の設定
+
+APIルートを登録：
+
+```php
+return Application::configure(basePath: dirname(__DIR__))
+    ->withRouting(
+        web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',  // この行を追加
+        commands: __DIR__.'/../routes/console.php',
+        health: '/up',
+    )
+```
+
+#### 4. Userモデルの更新
+
+`app/Models/User.php`に`HasApiTokens`トレイトを追加：
+
+```php
+use Laravel\Sanctum\HasApiTokens;
+
+class User extends Authenticatable
+{
+    use HasApiTokens, HasFactory, Notifiable, TwoFactorAuthenticatable;
+    
+    // ...
+}
+```
+
+#### 5. マイグレーションの実行
+
+```bash
+php artisan migrate
+```
+
+#### 6. 設定キャッシュのクリア
+
+```bash
+php artisan config:clear
+```
+
+## API認証の使用方法
+
+### routes/api.php での使用例
+
+```php
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Api\UserController;
+
+Route::middleware('auth:sanctum')->group(function () {
+    Route::apiResource('users', UserController::class)->names([
+        'index' => 'api.users.index',
+        'store' => 'api.users.store',
+        'show' => 'api.users.show',
+        'update' => 'api.users.update',
+        'destroy' => 'api.users.destroy',
+    ]);
+});
+```
+
+## SPA認証の設定（InertiaアプリからAPIを呼び出す場合）
+
+**重要**: SPAからのセッションベース認証を使う場合、APIルートは`web`ミドルウェアグループを通す必要があります。
+
+### 1. APIルートを`web`ミドルウェアグループに含める
+
+`routes/web.php`にAPIルートを読み込む：
+
+```php
+require __DIR__.'/api.php';
+```
+
+`routes/api.php`でプレフィックスとミドルウェアを指定：
+
+```php
+Route::prefix('api')->middleware('auth')->group(function () {
+    Route::apiResource('users', UserController::class)->names([
+        'index' => 'api.users.index',
+        // ...
+    ]);
+});
+```
+
+`bootstrap/app.php`では、`api`ルートの登録を削除（`web`から読み込むため）：
+
+```php
+return Application::configure(basePath: dirname(__DIR__))
+    ->withRouting(
+        web: __DIR__.'/../routes/web.php',
+        // api: __DIR__.'/../routes/api.php', ← この行を削除
+        commands: __DIR__.'/../routes/console.php',
+        health: '/up',
+    )
+```
+
+### 2. CSRFトークンの設定
+
+`resources/views/app.blade.php`に追加：
+
+```html
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <!-- 他のヘッダー要素 -->
+</head>
+```
+
+### 3. axiosの設定
+
+`resources/js/app.ts`に追加：
+
+```typescript
+import axios from 'axios';
+
+// Sanctum用のaxios設定
+axios.defaults.withCredentials = true;
+axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
+
+// CSRFトークンをaxiosに設定
+const token = document.head.querySelector('meta[name="csrf-token"]');
+if (token) {
+    axios.defaults.headers.common['X-CSRF-TOKEN'] = token.getAttribute('content');
+}
+```
+
+### 4. VueコンポーネントからAPIを呼び出す
+
+```vue
+<script setup lang="ts">
+import axios from 'axios';
+import { ref } from 'vue';
+
+const users = ref<User[]>([]);
+
+const searchUsers = async () => {
+  const response = await axios.get('/api/users', { 
+    params: { name: name.value, email: email.value } 
+  });
+  users.value = response.data;
+};
+</script>
+```
+
+## トラブルシューティング
+
+### エラー: Auth guard [sanctum] is not defined.
+
+以下の点を確認：
+1. `config/auth.php`に`sanctum`ガードが定義されているか
+2. `bootstrap/app.php`で`api`ルートが登録されているか
+3. `User`モデルに`HasApiTokens`トレイトが追加されているか
+4. 設定キャッシュをクリアしたか（`php artisan config:clear`）
+
+### エラー: {"message":"Unauthenticated."}
+
+InertiaアプリからaxiosでAPIを呼び出す際に認証エラーが出る場合：
+
+#### クッキー（XSRF-TOKEN、laravel_session）が送信されているのに認証エラーが出る
+
+**原因**: APIルートが`api`ミドルウェアグループで登録されており、セッション管理が機能していない。
+
+**解決策**: APIルートを`web`ミドルウェアグループに含める
+
+1. `routes/web.php`で`routes/api.php`を読み込む
+   ```php
+   require __DIR__.'/api.php';
+   ```
+
+2. `routes/api.php`でプレフィックスとミドルウェアを指定
+   ```php
+   Route::prefix('api')->middleware('auth')->group(function () {
+       // APIルート定義
+   });
+   ```
+
+3. `bootstrap/app.php`から`api`ルートの登録を削除
+   ```php
+   ->withRouting(
+       web: __DIR__.'/../routes/web.php',
+       // api: __DIR__.'/../routes/api.php', ← 削除
+       commands: __DIR__.'/../routes/console.php',
+   )
+   ```
+
+4. キャッシュをクリア
+   ```bash
+   php artisan route:clear
+   php artisan config:clear
+   ```
+
+#### その他の確認事項
+
+1. **CSRFトークンが設定されているか確認**
+   - `app.blade.php`に`<meta name="csrf-token">`が追加されているか
+   - `app.ts`でaxiosにCSRFトークンが設定されているか
+
+2. **axiosの設定を確認**
+   - `axios.defaults.withCredentials = true`が設定されているか
+   - `axios.defaults.headers.common['X-CSRF-TOKEN']`が設定されているか
+
+3. **フロントエンドをビルド**
+   ```bash
+   npm run build
+   ```
+   または開発環境の場合：
+   ```bash
+   npm run dev
+   ```
+
+4. **ブラウザをリロード**
+   - キャッシュをクリアしてページをリロードする
+


### PR DESCRIPTION
feat: laravel-query-builder導入
feat: プロジェクト詳細画面にメンバー追加モーダルを追加、API越しにユーザー一覧を取得
feat: モーダルからメンバー追加、画面のみ
feat: メンバー追加をShowじゃなくEditでやるように修正、フォームをCreateとEditで使いまわすように修正
feat: メンバー一覧の表示と追加と送信するところまで

```
git rebase -i HEAD~6
```

HEADも数えて6つ分